### PR TITLE
Add no analytics page to test website

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -14,6 +14,7 @@
 
       <nav>
         <a href="/">Home</a>
+        <a href="/noanalytics">No Analytics</a>
         <a href="/ua">Universal Analytics</a>
         <a href="/ga4">Google Analytics 4</a>
         <a href="/dualtagging">Dual Tagging</a>

--- a/src/noanalytics/index.njk
+++ b/src/noanalytics/index.njk
@@ -1,0 +1,9 @@
+---
+title: No Analytics
+layout: "base.njk"
+---
+
+{% include "_form.html" %}
+
+<script src="../scripts/common.js"></script>
+<script src="../scripts/no-analytics-handlers.js"></script>

--- a/src/scripts/no-analytics-handlers.js
+++ b/src/scripts/no-analytics-handlers.js
@@ -1,0 +1,7 @@
+function handleLinkClick(event) {
+    event.preventDefault();
+}
+
+function handleFormSubmit(event) {
+    event.preventDefault();
+}


### PR DESCRIPTION
Did this all in rails on the other repo initially, surprised at how lightweight njk seems. I think my changes achieve what we want, that is no scripts on the page. 

Wasn't exactly clear on how the urls work, I assumed it was based on the file structure in the repo? 